### PR TITLE
Adding Python requirements and avoiding error with rm

### DIFF
--- a/make1D
+++ b/make1D
@@ -11,4 +11,4 @@ images: simulacion.c
 .PHONY: clean
 clean:
 	@echo eliminando archivos temporales
-	rm heh.a oI.dat oR.dat outF0.dat outF1.dat inF.dat
+	rm heh.a

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -1,0 +1,4 @@
+numpy
+scipy
+matplotlib
+imageio


### PR DESCRIPTION
I just clone the repository and run it. First of all, I think you've done a great job.

To make easier to somebody to try to code, I think Python requirements should be added 
acdc641 . I install a virtual environment in Python 3.6 and I needed to install some libraries, since you use them in your code. There are listed in `pip_requirements.txt`, so if you run:

```bash
pip install -r pip_requirements.txt
```

Then you shouldn't need anything more.

Then, I realized `make1D` has more remove commands than `make2D` and `make3D`, so it gives me an error. They are deleted in eea06d5 .